### PR TITLE
Refactor to use config, fix pipeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 SDK For Simplified usage of Gemini Agents. Give Gemini Ability to use your custom functions in seveal code lines:
 
 ```python
+import config.config as config
 from gemini_agents_toolkit import agent
 
 import vertexai
@@ -11,10 +12,10 @@ def say_to_duck(say: str):
     return f"duck answer is: duck duck {say} duck duck duck"
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 all_functions = [say_to_duck]
-duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name="gemini-1.5-flash")
+duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name=config.simple_model)
 
 print(duck_comms_agent.send_message("say to the duck message: I am hungry"))
 ```
@@ -22,12 +23,13 @@ print(duck_comms_agent.send_message("say to the duck message: I am hungry"))
 Here is more complex example of several agents that delegating tasks to each other:
 
 ```python
+import config.config as config
 from gemini_agents_toolkit import agent
 
 import vertexai
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 
 def generate_duck_comms_agent():
@@ -37,7 +39,7 @@ def generate_duck_comms_agent():
     return agent.create_agent_from_functions_list(
         functions=[say_to_duck], 
         delegation_function_prompt="Agent can communicat to ducks and can say something to them. And provides the answer from the duck.", 
-        model_name="gemini-1.5-flash")
+        model_name=config.simple_model)
 
 
 def generate_time_checker_agent():
@@ -48,13 +50,13 @@ def generate_time_checker_agent():
     return agent.create_agent_from_functions_list(
         functions=[get_local_time], 
         delegation_function_prompt="Agent can provide the current local time.", 
-        model_name="gemini-1.5-flash")
+        model_name=config.simple_model)
 
 
 duck_comms_agent = generate_duck_comms_agent()
 time_checker_agent = generate_time_checker_agent()
 
-main_agent = agent.create_agent_from_functions_list(delegates=[time_checker_agent, duck_comms_agent], model_name="gemini-1.5-flash")
+main_agent = agent.create_agent_from_functions_list(delegates=[time_checker_agent, duck_comms_agent], model_name=config.simple_model)
 
 print(main_agent.send_message("say to the duck message: I am hungry"))
 print(main_agent.send_message("can you tell me what time it is?"))
@@ -63,6 +65,7 @@ print(main_agent.send_message("can you tell me what time it is?"))
 Example of how you can call periodic task:
 
 ```python
+import config.config as config
 from gemini_agents_toolkit import agent
 import time
 
@@ -78,10 +81,10 @@ def print_msg_from_agent(msg: str):
     print(msg)
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 all_functions = [say_to_duck]
-duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name="gemini-1.5-flash", add_scheduling_functions=True, on_message=print_msg_from_agent)
+duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name=config.simple_model, add_scheduling_functions=True, on_message=print_msg_from_agent)
 
 # no need to print result directly since we passed to agent on_message
 duck_comms_agent.send_message("can you be saying, each minute, to the duck that I am hungry")

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,10 @@
+import os
+
+# ***** Google Cloud project settings *****
+project_id =  os.getenv('GOOGLE_PROJECT')
+api_key =  os.getenv('GOOGLE_API_KEY')
+region = os.environ.get('GOOGLE_REGION', 'us-west1')
+
+default_model = 'gemini-1.5-pro'
+# simple model is used for demo examples as a cost optimization
+simple_model = 'gemini-1.5-flash'

--- a/examples/investing_pipeline_example.py
+++ b/examples/investing_pipeline_example.py
@@ -1,3 +1,4 @@
+import config.config as config
 from gemini_agents_toolkit import agent
 from gemini_agents_toolkit.pipeline.eager_pipeline import EagerPipeline
 
@@ -72,12 +73,12 @@ def check_how_many_shares_i_own():
     return 30 + random.randint(-20, 1)
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 all_functions = [check_if_limit_sell_order_exists, cancel_limit_sell_order, set_limit_sell_order, check_current_tqqq_price, check_if_limit_buy_order_exists, get_current_limit_buy_price, cancel_limit_buy_order, set_limit_buy_order, check_how_many_shares_i_own]
-investor_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name="gemini-1.5-pro")
+investor_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name=config.default_model)
 
-pipeline = EagerPipeline(investor_agent)
+pipeline = EagerPipeline(default_agent=investor_agent)
 if not pipeline.boolean_step("check if I own more than 30 shares of TQQQ"):
     if not pipeline.boolean_step("is there a limit sell for TQQQ exists already?"):
         pipeline.step("check current price of TQQQ")

--- a/examples/multi_agent_example.py
+++ b/examples/multi_agent_example.py
@@ -1,9 +1,10 @@
+import config.config as config
 from gemini_agents_toolkit import agent
 
 import vertexai
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 
 def generate_duck_comms_agent():
@@ -13,7 +14,7 @@ def generate_duck_comms_agent():
     return agent.create_agent_from_functions_list(
         functions=[say_to_duck], 
         delegation_function_prompt="Agent can communicat to ducks and can say something to them. And provides the answer from the duck.", 
-        model_name="gemini-1.5-flash")
+        model_name=config.simple_model)
 
 
 def generate_time_checker_agent():
@@ -24,13 +25,13 @@ def generate_time_checker_agent():
     return agent.create_agent_from_functions_list(
         functions=[get_local_time], 
         delegation_function_prompt="Agent can provide the current local time.", 
-        model_name="gemini-1.5-flash")
+        model_name=config.simple_model)
 
 
 duck_comms_agent = generate_duck_comms_agent()
 time_checker_agent = generate_time_checker_agent()
 
-main_agent = agent.create_agent_from_functions_list(delegates=[time_checker_agent, duck_comms_agent], model_name="gemini-1.5-flash")
+main_agent = agent.create_agent_from_functions_list(delegates=[time_checker_agent, duck_comms_agent], model_name=config.simple_model)
 
 print(main_agent.send_message("say to the duck message: I am hungry"))
 print(main_agent.send_message("can you tell me what time it is?"))

--- a/examples/pipeline_example.py
+++ b/examples/pipeline_example.py
@@ -1,3 +1,4 @@
+import config.config as config
 from gemini_agents_toolkit import agent
 from gemini_agents_toolkit.pipeline.basic_step import BasicStep
 
@@ -9,12 +10,12 @@ def say_to_duck(say: str):
     return f"duck answer is: duck duck {say} duck duck duck"
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 all_functions = [say_to_duck]
-duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name="gemini-1.5-flash")
-computation_agent = agent.create_agent_from_functions_list(model_name="gemini-1.5-pro", system_instruction="you are agent design to do computation")
-printing_agent = agent.create_agent_from_functions_list(model_name="gemini-1.5-pro", system_instruction="you are agent design to do nice prints in the shell. You do not have to be producing BASH commands your output will be printed by other developer in the bush you are ONLY in charge of the formattin ASCII characters that will be printed. No need to even use characters like ``` before/after you response")
+duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name=config.simple_model)
+computation_agent = agent.create_agent_from_functions_list(model_name=config.default_model, system_instruction="you are agent design to do computation")
+printing_agent = agent.create_agent_from_functions_list(model_name=config.default_model, system_instruction="you are agent design to do nice prints in the shell. You do not have to be producing BASH commands your output will be printed by other developer in the bush you are ONLY in charge of the formattin ASCII characters that will be printed. No need to even use characters like ``` before/after you response")
 
 pipeline = (BasicStep(duck_comms_agent, "say to duck: I am hungry") | 
             BasicStep(computation_agent, "calculate how many times word duck was used in the response") | 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -1,3 +1,4 @@
+import config.config as config
 from gemini_agents_toolkit import agent
 
 import vertexai
@@ -8,9 +9,9 @@ def say_to_duck(say: str):
     return f"duck answer is: duck duck {say} duck duck duck"
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 all_functions = [say_to_duck]
-duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name="gemini-1.5-flash")
+duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name=config.simple_model)
 
 print(duck_comms_agent.send_message("say to the duck message: I am hungry"))

--- a/examples/simple_scheduler_example.py
+++ b/examples/simple_scheduler_example.py
@@ -1,3 +1,4 @@
+import config.config as config
 from gemini_agents_toolkit import agent
 import time
 
@@ -13,10 +14,10 @@ def print_msg_from_agent(msg: str):
     print(msg)
 
 
-vertexai.init(project="gemini-trading-backend", location="us-west1")
+vertexai.init(project=config.project_id, location=config.region)
 
 all_functions = [say_to_duck]
-duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name="gemini-1.5-flash", add_scheduling_functions=True, on_message=print_msg_from_agent)
+duck_comms_agent = agent.create_agent_from_functions_list(functions=all_functions, model_name=config.simple_model, add_scheduling_functions=True, on_message=print_msg_from_agent)
 
 # no need to print result directly since we passed to agent on_message
 duck_comms_agent.send_message("can you be saying, each minute, to the duck that I am hungry")

--- a/gemini_agents_toolkit/agent.py
+++ b/gemini_agents_toolkit/agent.py
@@ -1,3 +1,4 @@
+import config.config as config
 from vertexai.generative_models import (
     Part, GenerativeModel,
 )
@@ -12,7 +13,7 @@ import re
 
 class GeminiAgent(object):
 
-    def __init__(self, model_name="gemini-1.5-pro", *, functions=None, system_instruction=None, delegation_function_prompt=None, delegates=None, debug=False, recreate_client_each_time=False, history_depth=-1, on_message=None):
+    def __init__(self, model_name=config.default_model, *, functions=None, system_instruction=None, delegation_function_prompt=None, delegates=None, debug=False, recreate_client_each_time=False, history_depth=-1, on_message=None):
         if not functions:
             functions = []
         self.functions = {func.__name__: func for func in functions}
@@ -196,7 +197,7 @@ def _generate_function_declaration(func, *, user_set_name=None, user_set_descrip
 
 def create_agent_from_functions_list(
         *, 
-        model_name="gemini-1.5-pro",
+        model_name=config.default_model,
         functions=[],
         system_instruction=None, 
         debug=False, 

--- a/gemini_agents_toolkit/bin/pipe.py
+++ b/gemini_agents_toolkit/bin/pipe.py
@@ -1,5 +1,5 @@
+import config.config as config
 import sys
-import os
 
 import google.generativeai as genai
 
@@ -17,9 +17,9 @@ def generate_client():
 	    "if you asked to update something most likely you need to show same data stracture but updated, in the same format. Do not show HOW to update data structure, update it and output the result.",
 	    "Here is how you might be used by user: cat file | you -p \"prompt\" >> result"
     ]
-    genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+    genai.configure(api_key=config.api_key)
 
-    return GenerativeModel(model_name="gemini-1.5-pro", system_instruction=system_instruction)
+    return GenerativeModel(model_name=config.default_model, system_instruction=system_instruction)
 
 gemini_model = generate_client()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 APScheduler==3.10.4
 google-cloud-storage==2.18.2
 google-cloud-aiplatform==1.58.*
+google-generativeai==0.8.*

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = read_requirements()
 
 setup(
     name='gemini_agents_toolkit',
-    version='2.2.2',
+    version='2.3.0',
     packages=find_packages(),
     description='Toolkit For Creating Gemini Based Agents',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Changes to simplify `gemini-agents-toolkit` dev set up:

- created a config for setting up values from envs and constants, refactored code to use the config
- added a new os envs `GOOGLE_PROJECT` and `GOOGLE_REGION`
- fixed a bug in EagerPipeline example
- added a missed lib to requirements
- updated version to **2.3.0 (partially compatible, os environment expects a new env GOOGLE_PROJECT with gcp project name)**