### PR TITLE
Updating examples for the new agent version, nit refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ python examples/multi_agent_example.py
 ```python
 import datetime
 import vertexai
-from config import (PROJECT_ID, REGION, SIMPLE_MODEL)
+from config import (PROJECT_ID, REGION, SIMPLE_MODEL, DEFAULT_MODEL)
 from gemini_agents_toolkit import agent
+from gemini_agents_toolkit.history_utils import summarize
 
 vertexai.init(project=PROJECT_ID, location=REGION)
 
@@ -175,7 +176,7 @@ def generate_duck_comms_agent():
         functions=[say_to_duck],
         delegation_function_prompt=("""Agent can communicat to ducks and can say something to them.
                                     And provides the answer from the duck."""),
-        model_name=SIMPLE_MODEL)
+        model_name=DEFAULT_MODEL)
 
 
 def generate_time_checker_agent():
@@ -198,8 +199,12 @@ main_agent = agent.create_agent_from_functions_list(
     delegates=[time_checker_agent, duck_comms_agent],
     model_name=SIMPLE_MODEL)
 
-print(main_agent.send_message("say to the duck message: I am hungry"))
-print(main_agent.send_message("can you tell me what time it is?"))
+result_say_operation, history_say_operation = main_agent.send_message("say to the duck message: I am hungry")
+result_time_operation, history_time_operation = main_agent.send_message("can you tell me what time it is?")
+
+print(result_say_operation)
+print(result_time_operation)
+print(summarize(agent=main_agent, history=history_say_operation + history_time_operation))
 ```
 </details>
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -12,6 +12,6 @@ SIMPLE_MODEL = 'gemini-1.5-flash-002'
 PRO_MODEL = 'gemini-1.5-pro-002'
 
 # We highly recommend using the PRO model for production use cases
-# There is a huge bug related to funciton calling that is much more
-# prominent if falsh model is used.
+# There is a huge bug related to function calling that is much more
+# prominent if flash model is used.
 DEFAULT_MODEL = PRO_MODEL

--- a/examples/multi_agent_example.py
+++ b/examples/multi_agent_example.py
@@ -2,8 +2,9 @@
 
 import datetime
 import vertexai
-from config import (PROJECT_ID, REGION, SIMPLE_MODEL)
+from config import (PROJECT_ID, REGION, SIMPLE_MODEL, DEFAULT_MODEL)
 from gemini_agents_toolkit import agent
+from gemini_agents_toolkit.history_utils import summarize
 
 vertexai.init(project=PROJECT_ID, location=REGION)
 
@@ -19,7 +20,7 @@ def generate_duck_comms_agent():
         functions=[say_to_duck],
         delegation_function_prompt=("""Agent can communicat to ducks and can say something to them.
                                     And provides the answer from the duck."""),
-        model_name=SIMPLE_MODEL)
+        model_name=DEFAULT_MODEL)
 
 
 def generate_time_checker_agent():
@@ -42,5 +43,9 @@ main_agent = agent.create_agent_from_functions_list(
     delegates=[time_checker_agent, duck_comms_agent],
     model_name=SIMPLE_MODEL)
 
-print(main_agent.send_message("say to the duck message: I am hungry"))
-print(main_agent.send_message("can you tell me what time it is?"))
+result_say_operation, history_say_operation = main_agent.send_message("say to the duck message: I am hungry")
+result_time_operation, history_time_operation = main_agent.send_message("can you tell me what time it is?")
+
+print(result_say_operation)
+print(result_time_operation)
+print(summarize(agent=main_agent, history=history_say_operation + history_time_operation))

--- a/examples/multi_agent_pipeline.py
+++ b/examples/multi_agent_pipeline.py
@@ -6,7 +6,7 @@ import vertexai
 from json_agent import create_agent as create_json_agent
 from config import (PROJECT_ID, REGION, DEFAULT_MODEL)
 from gemini_agents_toolkit import agent
-from gemini_agents_toolkit.pipeline.eager_pipeline import EagerPipeline
+from gemini_agents_toolkit.pipeline import Pipeline
 
 
 def pwd() -> str:
@@ -74,8 +74,8 @@ fs_agent = agent.create_agent_from_functions_list(functions=all_functions, model
                                                   system_instruction=FS_AGENT_SYSTEM_INSTRUCTION)
 json_agent = create_json_agent(model_name=DEFAULT_MODEL)
 
-pipeline = EagerPipeline(default_agent=fs_agent)
-pipeline.step("read the content of the file examples/test.yaml")
-pipeline.step("convert yaml to json", agent=json_agent)
-pipeline.step("save json to file examples/test_out.json")
-print(pipeline.summary())
+pipeline = Pipeline(default_agent=fs_agent)
+_, history_step_1 = pipeline.step("read the content of the file examples/test.yaml")
+_, history_step_2 = pipeline.step("convert content of test.yaml to json", agent=json_agent, history=history_step_1)
+_, history_step_3 = pipeline.step("save json to file examples/test_out.json using valid json format without '\\n'", history=history_step_2)
+print(pipeline.summarize_full_history())

--- a/examples/run_all_examples.sh
+++ b/examples/run_all_examples.sh
@@ -2,7 +2,6 @@
 
 python ./examples/simple_example.py
 python ./examples/multi_agent_example.py
-python ./examples/pipeline_example.py
 python ./examples/investing_pipeline_example.py
 python ./examples/multi_agent_pipeline.py
 python ./examples/simple_scheduler_example.py

--- a/gemini_agents_toolkit/history_utils.py
+++ b/gemini_agents_toolkit/history_utils.py
@@ -1,13 +1,13 @@
 def summarize(*, agent, history):
     """Summarize the pipeline"""
-    prompt = f"""Now if the final step of the pipeline/dialog, provide summary of main things that were done and why.
+    prompt = """Now if the final step of the pipeline/dialog, provide summary of main things that were done and why.
         do not omit any steps, and only print key details. This dialog was a pipline so do not assume user knows about
-        any messages even if they were comming from the user before, now is the time to build proper summary for a user."""
+        any messages even if they were coming from the user before, now is the time to build proper summary for a user."""
     return agent.send_message(prompt, history=history)
 
 
 def trim_history(*, history, max_length):
-    """Trim history to only include the last specfified number of user messages"""
+    """Trim history to only include the last specified number of user messages"""
     if len(history) <= max_length:
         return history
     

--- a/gemini_agents_toolkit/pipeline/__init__.py
+++ b/gemini_agents_toolkit/pipeline/__init__.py
@@ -1,6 +1,6 @@
 from vertexai.generative_models import GenerationConfig
 from gemini_agents_toolkit.history_utils import summarize
-from gemini_agents_toolkit import agent
+from gemini_agents_toolkit import agent as agent_toolkit
 from config import (SIMPLE_MODEL)
 
 
@@ -16,14 +16,14 @@ class Pipeline(object):
                 response_mime_type="application/json",
                 temperature=0
             )
-            self.convert_to_bool_agent = agent.create_agent_from_functions_list(model_name=SIMPLE_MODEL, generation_config=generation_config)
+            self.convert_to_bool_agent = agent_toolkit.create_agent_from_functions_list(model_name=SIMPLE_MODEL, generation_config=generation_config)
 
     def _get_agent(self, agent):
         if agent:
             return agent
         if self.agent:
             return self.agent
-        raise ValueError("either default agent or local(per ste) agent should be set")
+        raise ValueError("either default agent or local(per step) agent should be set")
 
     def if_step(self, prompt, then_steps=None, else_steps=None, *, agent=None, history=None):
         agent_to_use = self._get_agent(agent)
@@ -54,7 +54,7 @@ class Pipeline(object):
     def step(self, prompt, *, agent=None, history=None):
         if self.logger:
             self.logger.info(f"step: {prompt}")
-        prompt = f"""this is one step in the pipeline, this steps are user command but not comming direclty from the user:
+        prompt = f"""this is one step in the pipeline, this steps are user command but not coming directly from the user:
         user prompt: {prompt}"""
         agent_to_use = self._get_agent(agent)
         result, updated_history = agent_to_use.send_message(prompt, history=history)
@@ -65,9 +65,9 @@ class Pipeline(object):
         if self.logger:
             self.logger.info(f"boolean_step: {prompt}")
 
-        #TODO think to rename puser prompt to simple user question. 
-        prompt = f"""this is one step in the pipeline, this steps are user command but not comming direclty from the user:
-        Following prompt provided by user, and user expects this to compute in a boolean yes/no answer, you have to retunr
+        #TODO think to rename user prompt to simple user question.
+        prompt = f"""this is one step in the pipeline, this steps are user command but not coming directly from the user:
+        Following prompt provided by user, and user expects this to compute in a boolean yes/no answer, you have to return
         True/False and nothing else in your response. 
         Prompt: {prompt}
         
@@ -80,11 +80,11 @@ class Pipeline(object):
         self._full_history.extend(history)
         if "true" in bool_answer.lower():
             if self.logger:
-                self.logger.info(f"boolean_step: True")
+                self.logger.info("boolean_step: True")
             return True, history
         elif "false" in bool_answer.lower():
             if self.logger:
-                self.logger.info(f"boolean_step: False")
+                self.logger.info("boolean_step: False")
             return False, history
         else:
             if self.logger:


### PR DESCRIPTION
Changes:
- Examles updated to be used with 3.x.x agent (get and provide history in pipeline steps)
- Readme update with new examples
- Nit fixing for typos

Caveat: json-agent needs to be udated to 3.x.x. toolkit version due to changed method signature